### PR TITLE
Refactor

### DIFF
--- a/src/main/java/gui/CommandBarController.java
+++ b/src/main/java/gui/CommandBarController.java
@@ -12,8 +12,9 @@ import main.java.logic.Logic;
 public class CommandBarController extends TextField {
 
     private static final String COMMAND_BAR_LAYOUT_FXML = "/main/resources/layouts/CommandBar.fxml";
+    private Logic logic;
 
-    public CommandBarController() {
+    public CommandBarController(Logic logic) {
         FXMLLoader loader = new FXMLLoader(getClass().getResource(COMMAND_BAR_LAYOUT_FXML));
         loader.setController(this);
         loader.setRoot(this);
@@ -22,16 +23,17 @@ public class CommandBarController extends TextField {
         } catch (IOException e) {
             e.printStackTrace();
         }
+        this.logic = logic;
     }
 
-    public CommandBarController(String text) {
-        this();
+    public CommandBarController(String text, Logic logic) {
+        this(logic);
         this.setText(text);
         this.selectAll();
     }
 
     @FXML
     public void onKeyPress(KeyEvent event) {
-        Logic.handleKeyPress(this, event.getCode(), this.getText());
+        logic.handleKeyPress(this, event.getCode(), this.getText());
     }
 }

--- a/src/main/java/gui/MainApp.java
+++ b/src/main/java/gui/MainApp.java
@@ -7,6 +7,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
 import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
+import main.java.logic.Logic;
 
 //@author Sebastian Quek
 public class MainApp extends Application {
@@ -27,10 +28,12 @@ public class MainApp extends Application {
     public void start(Stage primaryStage) {
         initRootLayout();
         initPrimaryStage(primaryStage);
+        
+        Logic logic = initLogic();
 
         // Add components to RootLayout
-        addCommandBar();
-        addOverview();        
+        addCommandBar(logic);
+        addOverview();
     }
 
     /**
@@ -56,12 +59,16 @@ public class MainApp extends Application {
         this.primaryStage.setScene(new Scene(rootLayout));
         this.primaryStage.show();
     }
+    
+    private Logic initLogic() {
+        return new Logic();       
+    }
 
     private void addOverview() {
         rootLayout.setCenter(new OverviewLayoutController());
     }
 
-    private void addCommandBar() {
-        rootLayout.setBottom(new CommandBarController(COMMAND_BAR_DEFAULT_TEXT));
+    private void addCommandBar(Logic logic) {
+        rootLayout.setBottom(new CommandBarController(COMMAND_BAR_DEFAULT_TEXT, logic));
     }
 }

--- a/src/main/java/logic/Command.java
+++ b/src/main/java/logic/Command.java
@@ -1,70 +1,44 @@
 package main.java.logic;
 
 public class Command {
-    
     public static enum Type {
         COLLATE, INVALID
     }
-    
-    private static final String STRING_ONE_SPACE = " ";
-    private static final int POSITION_PARAM_COMMAND = 0;
-    private static final int POSITION_FIRST_PARAM_ARGUMENT = 1;
-    
-    private static final String USER_COMMAND_COLLATE = "collate";
-    
-    private Type commandType;
-    private String arguments;
-    
-    public Command(String userInput) {
-        String[] parameters = splitUserInput(userInput);
-        
-        String userCommand = getUserCommand(parameters);
-        commandType = determineCommandType(userCommand);
-        
-        arguments = getUserArguments(parameters);
+
+    private Type type;
+    private String directory;
+    private boolean scanCurrentDirOnly;
+
+    public Command() {
+        setScanCurrentDirOnly(false);
     }
-    
+
     // ================================================================
     // Public getters
     // ================================================================
-    
+
     public Type getCommandType() {
-        return commandType;
+        return type;
     }
 
-    public String getArguments() {
-        return arguments;
-    }
-    
-    
-    // ================================================================
-    // Private methods
-    // ================================================================
-    
-    private Type determineCommandType(String userCommand) {
-        switch (userCommand.toLowerCase()) {
-            case USER_COMMAND_COLLATE :
-                return Type.COLLATE;
-            default :
-                return Type.INVALID;
-        }
+    public void setType(Type type) {
+        this.type = type;
     }
 
-    private String getUserArguments(String[] parameters) {
-        StringBuilder builder = new StringBuilder();
-        for (int i = POSITION_FIRST_PARAM_ARGUMENT; i < parameters.length; i++) {
-            builder.append(parameters[i]);
-            builder.append(STRING_ONE_SPACE);
-        }
-        return builder.toString().trim();
+    public String getDirectory() {
+        return directory;
     }
 
-    private String getUserCommand(String[] parameters) {
-        return parameters[POSITION_PARAM_COMMAND];
+    public void setDirectory(String directory) {
+        this.directory = directory;
     }
 
-    private String[] splitUserInput(String input) {
-        return input.trim().split(STRING_ONE_SPACE);
+    public boolean willScanCurrentDirOnly() {
+        return scanCurrentDirOnly;
+    }
+
+    public void setScanCurrentDirOnly(boolean scanCurrentDirOnly) {
+        this.scanCurrentDirOnly = scanCurrentDirOnly;
     }
 
 }

--- a/src/main/java/logic/Logic.java
+++ b/src/main/java/logic/Logic.java
@@ -19,26 +19,26 @@ import main.java.storage.CollatedFilesStorage;
 
 public class Logic {
 
-    private static Logger logger;
-    private static CommandParser commandParser;
-    private static CollatedFilesStorage collatedFilesStorage;
-    private static HashMap<String, Author> authors;
-    private static String rootDirectory;
+    private Logger logger;
+    private CommandParser commandParser;
+    private CollatedFilesStorage collatedFilesStorage;
+    private HashMap<String, Author> authors;
+    private String rootDirectory;
 
     private static final String LOG_TAG = "Logic";
     private static final int INITIAL_NUM_CONTRIBUTORS = 5;
     private static final String JAVA_AUTHOR_TAG = "@author";
 
-    static {
+    public Logic() {
         logger = Logger.getLogger(LOG_TAG);
         commandParser = new CommandParser();
         collatedFilesStorage = new CollatedFilesStorage();
         authors = new HashMap<String, Author>(INITIAL_NUM_CONTRIBUTORS);
     }
 
-    public static void handleKeyPress(CommandBarController commandBar,
-                                      KeyCode key,
-                                      String userInput) {
+    public void handleKeyPress(CommandBarController commandBar,
+                               KeyCode key,
+                               String userInput) {
         if (key == KeyCode.ENTER) {
             handleEnterPress(userInput);
             commandBar.clear();
@@ -50,7 +50,7 @@ public class Logic {
     // Private methods
     // ================================================================
 
-    private static void handleEnterPress(String userInput) {
+    private void handleEnterPress(String userInput) {
         Command command = new Command(userInput);
         executeCommand(command);
 
@@ -68,7 +68,7 @@ public class Logic {
         OverviewLayoutController.updateOverviewDisplay(data, true);
     }
 
-    private static void executeCommand(Command command) {
+    private void executeCommand(Command command) {
         switch (command.getCommandType()) {
             case COLLATE :
                 handleCollate(command.getArguments());
@@ -84,10 +84,10 @@ public class Logic {
     // Collate methods
     // ================================================================
 
-    private static void handleCollate(String arguments) {
+    private void handleCollate(String arguments) {
         rootDirectory = commandParser.getDirectory(arguments);
         boolean hasRecursionFlag = commandParser.hasRecursionFlag(arguments);
-        
+
         if (rootDirectory != null) {
             authors = new HashMap<String, Author>(INITIAL_NUM_CONTRIBUTORS);
             traverseDirectory(rootDirectory, hasRecursionFlag);
@@ -95,8 +95,7 @@ public class Logic {
         }
     }
 
-    private static void traverseDirectory(String directory,
-                                          boolean willScanSubFolders) {
+    private void traverseDirectory(String directory, boolean willScanSubFolders) {
         File folder = new File(directory);
         if (folder.isFile()) {
             collateFile(folder);
@@ -105,7 +104,7 @@ public class Logic {
         }
     }
 
-    private static void saveCollatedFiles() {
+    private void saveCollatedFiles() {
         for (Author author : authors.values()) {
             ArrayList<String> collatedLines = new ArrayList<String>();
             collatedLines.add("# " + author.getName());
@@ -117,8 +116,7 @@ public class Logic {
         }
     }
 
-    private static void traverseDirectory(File folder,
-                                          boolean willScanSubFolders) {
+    private void traverseDirectory(File folder, boolean willScanSubFolders) {
         for (File file : folder.listFiles()) {
             if (willScanSubFolders && file.isDirectory()) {
                 traverseDirectory(file, willScanSubFolders);
@@ -129,7 +127,7 @@ public class Logic {
         }
     }
 
-    private static void collateFile(File file) {
+    private void collateFile(File file) {
         try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
             String line = reader.readLine();
             Author currentAuthor = null;
@@ -164,19 +162,19 @@ public class Logic {
         }
     }
 
-    private static String getRelativePath(String path) {
+    private String getRelativePath(String path) {
         if (path.equals(rootDirectory)) {
             return path.substring(path.lastIndexOf("\\") + 1);
         }
         return path.replace(rootDirectory, "").substring(1);
     }
 
-    private static String findAuthorName(String line) {
+    private String findAuthorName(String line) {
         String[] split = line.split(JAVA_AUTHOR_TAG);
         return split[1].trim();
     }
 
-    private static String getFileExtension(File file) {
+    private String getFileExtension(File file) {
         int idxLastPeriod = file.getName().lastIndexOf('.');
         if (idxLastPeriod != -1) {
             return file.getName().substring(idxLastPeriod + 1);

--- a/src/main/java/logic/Logic.java
+++ b/src/main/java/logic/Logic.java
@@ -27,7 +27,7 @@ public class Logic {
 
     private static final String LOG_TAG = "Logic";
     private static final int INITIAL_NUM_CONTRIBUTORS = 5;
-    private static final String JAVA_AUTHOR_TAG = "@author";
+    private static final String AUTHOR_TAG = "@author";
 
     public Logic() {
         logger = Logger.getLogger(LOG_TAG);
@@ -138,8 +138,8 @@ public class Logic {
 
             while (line != null) {
 
-                if (line.contains(JAVA_AUTHOR_TAG)) {
-                    String authorName = findAuthorName(line, JAVA_AUTHOR_TAG);
+                if (line.contains(AUTHOR_TAG)) {
+                    String authorName = findAuthorName(line, AUTHOR_TAG);
                     logger.log(Level.INFO, "Found author: " + authorName);
 
                     if (!authors.containsKey(authorName)) {
@@ -174,7 +174,7 @@ public class Logic {
 
     private String findAuthorName(String line, String authorTag) {
         String[] split = line.split(authorTag);
-        return split[1].trim();
+        return split[1].replaceAll("[^ a-zA-Z0-9]+", "").trim();
     }
 
     private String getFileExtension(File file) {

--- a/src/main/java/logic/parser/CommandParser.java
+++ b/src/main/java/logic/parser/CommandParser.java
@@ -3,34 +3,96 @@ package main.java.logic.parser;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import main.java.logic.Command;
+
 public class CommandParser {
-    
-    private static final String NO_RECURSION_KEYWORD = "only";
-    private static final String DIRECTORY_KEYWORD = "from";
+    private static final int POSITION_PARAM_COMMAND = 0;
+    private static final int POSITION_FIRST_PARAM_ARGUMENT = 1;
     private static final String STRING_ONE_SPACE = " ";
+
+    private static final String USER_COMMAND_COLLATE = "collate";
     
+    private static final String SCAN_CURRENT_DIR_ONLY_KEYWORD = "only";
+    private static final String DIRECTORY_KEYWORD = "from";
+
+
     public CommandParser() {
     }
 
-    public String getDirectory(String arguments) {
-        if (arguments != null) {
-            ArrayList<String> argArray = splitArguments(arguments);
-            if (argArray.contains(DIRECTORY_KEYWORD)) {
-                int directoryIndex = argArray.indexOf(DIRECTORY_KEYWORD) + 1;
-                return argArray.get(directoryIndex);
-            }
+    public Command parse(String userInput) {
+        Command command;
+        ArrayList<String> parameters = splitString(userInput, STRING_ONE_SPACE);
+        String userCommand = getUserCommand(parameters);
+        ArrayList<String> arguments = getUserArguments(parameters);
+
+        switch (userCommand.toLowerCase()) {
+            case USER_COMMAND_COLLATE :
+                command = initCollateCommand(arguments);
+                break;
+            default :
+                command = initInvalidCommand();
         }
-        return null;
+
+        return command;
     }
-    
-    public boolean hasRecursionFlag(String arguments) {
-        ArrayList<String> argArray = splitArguments(arguments);
-        return !argArray.contains(NO_RECURSION_KEYWORD);
-    }
-    
-    private ArrayList<String> splitArguments(String arguments) {
-        String[] strArray = arguments.trim().split(STRING_ONE_SPACE);
+
+
+    // ================================================================
+    // Private methods
+    // ================================================================
+
+    private ArrayList<String> splitString(String arguments, String delimiter) {
+        String[] strArray = arguments.trim().split(delimiter);
         return new ArrayList<String>(Arrays.asList(strArray));
     }
 
+    private String getUserCommand(ArrayList<String> parameters) {
+        return parameters.get(POSITION_PARAM_COMMAND);
+    }
+
+    private ArrayList<String> getUserArguments(ArrayList<String> parameters) {
+        return new ArrayList<String>(parameters.subList(POSITION_FIRST_PARAM_ARGUMENT,
+                                                        parameters.size()));
+    }
+
+
+    // ================================================================
+    // Create collate command methods
+    // ================================================================
+
+    private Command initCollateCommand(ArrayList<String> arguments) {
+        Command command = new Command();
+        command.setType(Command.Type.COLLATE);
+        command.setDirectory(findDirectory(arguments));
+        command.setScanCurrentDirOnly(hasScanCurrentDirOnlyKeyword(arguments));
+        return command;
+    }
+
+
+    private boolean hasScanCurrentDirOnlyKeyword(ArrayList<String> arguments) {
+        return arguments.contains(SCAN_CURRENT_DIR_ONLY_KEYWORD);
+    }
+
+    private String findDirectory(ArrayList<String> arguments) {
+        if (arguments.contains(DIRECTORY_KEYWORD)) {
+            int directoryIndex = arguments.indexOf(DIRECTORY_KEYWORD) + 1;
+            try {
+                return arguments.get(directoryIndex);
+            } catch (IndexOutOfBoundsException e) {
+                return "";
+            }
+        }
+        return "";
+    }
+
+
+    // ================================================================
+    // Create invalid command method
+    // ================================================================
+
+    private Command initInvalidCommand() {
+        Command command = new Command();
+        command.setType(Command.Type.INVALID);
+        return command;
+    }
 }


### PR DESCRIPTION
Logic now utilises CommandParser's parse method to obtain a Command object which contains all the initialised fields such as type of command and directory that collate should scan.

The current implementation does not differentiate between "collate" commands and other commands such as "invalid" commands. As such, the semantics of the fields of the Command object do not always make sense. E.g An "invalid" command will have the "directory" field which is set to null.
